### PR TITLE
Fix pending function after Farm rewards end

### DIFF
--- a/contracts/Farm.sol
+++ b/contracts/Farm.sol
@@ -120,9 +120,9 @@ contract Farm is Ownable {
         UserInfo storage user = userInfo[_pid][_user];
         uint256 accERC20PerShare = pool.accERC20PerShare;
         uint256 lpSupply = pool.lpToken.balanceOf(address(this));
+        uint256 lastBlock = block.number < endBlock ? block.number : endBlock;
 
-        if (block.number > pool.lastRewardBlock && lpSupply != 0) {
-            uint256 lastBlock = block.number < endBlock ? block.number : endBlock;
+        if (lastBlock > pool.lastRewardBlock && block.number > pool.lastRewardBlock && lpSupply != 0) {
             uint256 nrOfBlocks = lastBlock.sub(pool.lastRewardBlock);
             uint256 erc20Reward = nrOfBlocks.mul(rewardPerBlock).mul(pool.allocPoint).div(totalAllocPoint);
             accERC20PerShare = accERC20PerShare.add(erc20Reward.mul(1e36).div(lpSupply));


### PR DESCRIPTION
When `endBlock` exceeds `lastRewardBlock`, there is a subtraction overflow at line 126. So the `lastBlock` calculation should occur outside of the inner loop; only enter the loop if `lastBlock` is greater than `lastRewardBlock`, otherwise just do the final calculation.